### PR TITLE
Freezing site array after initialization to prevent people from overwrit...

### DIFF
--- a/lib/hostel.rb
+++ b/lib/hostel.rb
@@ -16,6 +16,7 @@ module Hostel
         site.instance_eval(&@site_initializer)
       end
     end
+    all.freeze
   end
 
   def self.pinning_enabled?


### PR DESCRIPTION
...ing the site variables

Freezing the "site" array in Hostel to prevent people from overwriting those variables later in CIO and causing problems.
