### PR TITLE
Allowing for alternative location of host request information

### DIFF
--- a/lib/hostel/detectable.rb
+++ b/lib/hostel/detectable.rb
@@ -14,6 +14,8 @@ module Hostel
         if site = Hostel.find(request.params[:pinned])
           cookies[:pinned] = site.key
           Hostel::Detector.new(site.domain).site
+        elsif request.headers['X-PROXIED-FOR']
+            Hostel::Detector.new(request.headers['X-PROXIED-FOR'], cookies[:pinned]).site
         else
           Hostel::Detector.new(request.host, cookies[:pinned]).site
         end

--- a/lib/hostel/domain_constraint.rb
+++ b/lib/hostel/domain_constraint.rb
@@ -5,7 +5,11 @@ module Hostel
     end
 
     def matches?(request)
-      current_site = Hostel::Detector.new(request.host, request.cookies['pinned']).site
+      if request.headers['X-PROXIED-FOR']
+        current_site = Hostel::Detector.new(request.headers['X-PROXIED-FOR'], request.cookies['pinned']).site
+      else
+        current_site = Hostel::Detector.new(request.host, request.cookies['pinned']).site
+      end
       @site_keys.include?(current_site.key)
     end
   end


### PR DESCRIPTION
updating hostel to allow it to look at an alternative header
for where the "hostname" is so that it can reside behind
nginx and work in heroku that way.
