### PR TITLE
README and env changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,17 @@ Example usage:
 
 * Build a link to the order page, with query parameters
 
-`current_site.build_path('order', params: { :incode => 'CIOSTUFF', :purchase_type => 'instructor_access' })`
+`current_site.build_path('order', path_args: { :incode => 'CIOSTUFF', :purchase_type => 'instructor_access' })`
 
 * Build a link to the Cooking School Courses page from Everest
 
-`Hostel.find('school_main').build_path('courses', secure: false, params: { :stuff => 'OTHERSTUFF' })`
+`Hostel.find('school_main').build_path('courses', secure: false, path_args: { :stuff => 'OTHERSTUFF' })`
 
 * Build a link to the support page
 
 `current_site.build_path(support_path, secure: false)`
+
+* Build a link to a page and have it work in the qa environment by specifiying the host
+
+'current_site.build_path(sign_in_path, request_host: request.server_name)}'
 

--- a/lib/hostel/site.rb
+++ b/lib/hostel/site.rb
@@ -14,14 +14,22 @@ module Hostel
     end
     
     # Constructs a url for a path on this site
-    def build_path(path, secure: true, path_args: {})
-      url = if secure
+    def build_path(path, secure: true, path_args: {}, request_host: nil)
+      local_env = domain.include? 'www-test'
+      qa_env = request_host&.include? 'qa.herokuapp.com'
+
+      url = if secure && !local_env
         'https://'
       else
         'http://'
       end
 
-      url << domain
+      qa_env ? url << request_host : url << domain
+
+      if local_env
+        url << ':' + ENV['WEBSERVERPORT']
+      end
+
       if path && !path.empty?
         url << '/' + path.gsub(/\A\/+/, "")
       end

--- a/lib/hostel/version.rb
+++ b/lib/hostel/version.rb
@@ -1,3 +1,3 @@
 module Hostel
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Hostel should now be able to handle building paths for both local and qa environments. However, pinning is not automatically added, meaning links to other sites will not actually direct you out of cio. Most functionality surrounding paths is in cio anyway, so I figured this wasn't necessary. 