### PR TITLE
making it so hostel will honor qa apps hostnames

### DIFF
--- a/lib/hostel/site.rb
+++ b/lib/hostel/site.rb
@@ -22,10 +22,10 @@ module Hostel
         'http://'
       end
 
-      url << domain
+      url << (ENV['QA_HOST'] || domain)
 
       if port
-        url<<":#{port}"
+        url << ":#{port}"
       end
 
       if path && !path.empty?

--- a/lib/hostel/version.rb
+++ b/lib/hostel/version.rb
@@ -1,3 +1,3 @@
 module Hostel
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
making it so hostel will honor qa apps by looking for a variable we already set in qa apps on heroku. The variable is QA_HOST
